### PR TITLE
Allow overriding CC

### DIFF
--- a/ext/getsource_base/extconf.rb
+++ b/ext/getsource_base/extconf.rb
@@ -1,6 +1,6 @@
 require 'mkmf'
 dir_config('getsource_base')
-MakeMakefile::CONFIG['CC'] = 'gcc'
+MakeMakefile::CONFIG['CC'] = ENV['CC'] or 'gcc'
 
 ruby_version = MakeMakefile::CONFIG["ruby_version"]
 ruby_version = ruby_version.split(".")[0..1].join(".")


### PR DESCRIPTION
This allows using a compiler other than `gcc` via the `CC` environment variable.